### PR TITLE
Handle SSL verification configuration for Bybit bot

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -9,11 +9,16 @@ def main() -> None:
         api_key=cfg.api_key,
         api_secret=cfg.api_secret,
         demo=cfg.demo,
-        ignore_ssl=cfg.ignore_ssl,
     )
+    if cfg.ignore_ssl:
+        session.client.verify = False
     print("Fetching account balance...")
-    result = session.get_wallet_balance(accountType="UNIFIED")
-    print(result)
+    try:
+        result = session.get_wallet_balance(accountType="UNIFIED")
+    except Exception as exc:
+        print(f"Failed to fetch balance: {exc}")
+    else:
+        print(result)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Remove unsupported `ignore_ssl` argument when creating the HTTP session
- Conditionally disable SSL verification and handle balance fetch errors gracefully

## Testing
- `python3 bot.py` *(fails: Http status code is not 200. (ErrCode: 401))*

------
https://chatgpt.com/codex/tasks/task_e_68921de2cf8c8320bfa5c7f1de96665b