### PR TITLE
Handle SSL verification configuration for Bybit bot

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,19 +1,32 @@
 from config import BybitConfig
 from pybit.unified_trading import HTTP
+import urllib3
 
 
 def main() -> None:
     cfg = BybitConfig.from_env()
+
     session = HTTP(
-        testnet=cfg.testnet,
+        testnet=False if cfg.demo else cfg.testnet,
         api_key=cfg.api_key,
         api_secret=cfg.api_secret,
         demo=cfg.demo,
-        ignore_ssl=cfg.ignore_ssl,
     )
+    if cfg.ignore_ssl:
+        session.client.verify = False
+        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
     print("Fetching account balance...")
-    result = session.get_wallet_balance(accountType="UNIFIED")
-    print(result)
+    try:
+        response = session.get_wallet_balance(accountType="UNIFIED")
+        if isinstance(response, tuple):
+            response = response[0]
+        if response.get("retCode") != 0:
+            raise RuntimeError(response.get("retMsg", "Unknown error"))
+    except Exception as exc:
+        print(f"Failed to fetch balance: {exc}")
+    else:
+        print(response)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Remove unsupported `ignore_ssl` argument when creating the HTTP session
- Conditionally disable SSL verification and handle balance fetch errors gracefully
- Suppress urllib3 SSL warnings when `ignore_ssl` is enabled
- Force demo mode to disable testnet and surface API `retCode` errors

## Testing
- `python3 bot.py` *(fails: Http status code is not 200. (ErrCode: 401))*

------
https://chatgpt.com/codex/tasks/task_e_68921de2cf8c8320bfa5c7f1de96665b