### PR TITLE
Implement order placement and closing with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,13 @@ Simple Bybit futures trading bot example.
    ```
 
 This example fetches and prints account balance using Bybit's demo environment.
+It also provides helpers for placing and closing leveraged market orders on
+`BTCUSDT`, `ETHUSDT`, `SOLUSDT`, `XRPUSDT`, `DOGEUSDT` and `BNBUSDT`.
+
+## Testing
+
+Run unit tests with:
+
+```bash
+pytest
+```

--- a/bot.py
+++ b/bot.py
@@ -3,6 +3,66 @@ from pybit.unified_trading import HTTP
 import urllib3
 
 
+class BybitTradingBot:
+    """Simple helper for placing and closing Bybit linear USDT orders."""
+
+    ALLOWED_SYMBOLS = [
+        "BTCUSDT",
+        "ETHUSDT",
+        "SOLUSDT",
+        "XRPUSDT",
+        "DOGEUSDT",
+        "BNBUSDT",
+    ]
+
+    def __init__(self, session: HTTP):
+        self.session = session
+
+    def _validate(self, symbol: str, amount: float, leverage: int) -> None:
+        if symbol not in self.ALLOWED_SYMBOLS:
+            raise ValueError("Unsupported trading pair")
+        if not 80 <= amount <= 120:
+            raise ValueError("Amount must be between 80 and 120 USD")
+        if not 10 <= leverage <= 20:
+            raise ValueError("Leverage must be between 10 and 20")
+
+    def place_order(self, symbol: str, side: str, amount: float, leverage: int) -> dict:
+        """Place a market order respecting risk limits."""
+        self._validate(symbol, amount, leverage)
+        qty = amount * leverage
+        self.session.set_leverage(
+            category="linear",
+            symbol=symbol,
+            buyLeverage=str(leverage),
+            sellLeverage=str(leverage),
+        )
+        return self.session.place_order(
+            category="linear",
+            symbol=symbol,
+            side=side,
+            orderType="Market",
+            qty=str(qty),
+            timeInForce="ImmediateOrCancel",
+        )
+
+    def close_position(
+        self, symbol: str, side: str, amount: float, leverage: int
+    ) -> dict:
+        """Close an existing position by placing an opposite market order."""
+        self._validate(symbol, amount, leverage)
+        qty = amount * leverage
+        close_side = "Sell" if side == "Buy" else "Buy"
+        return self.session.place_order(
+            category="linear",
+            symbol=symbol,
+            side=close_side,
+            orderType="Market",
+            qty=str(qty),
+            timeInForce="ImmediateOrCancel",
+            reduceOnly=True,
+        )
+
+
 def main() -> None:
     cfg = BybitConfig.from_env()
     session = HTTP(
@@ -13,9 +73,9 @@ def main() -> None:
     )
     if cfg.ignore_ssl:
         session.client.verify = False
-
         urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
+    bot = BybitTradingBot(session)
     print("Fetching account balance...")
     try:
         result = session.get_wallet_balance(accountType="UNIFIED")
@@ -23,6 +83,9 @@ def main() -> None:
         print(f"Failed to fetch balance: {exc}")
     else:
         print(result)
+    # Example usage (requires valid API keys):
+    # bot.place_order("BTCUSDT", "Buy", 100, 10)
+    # bot.close_position("BTCUSDT", "Buy", 100, 10)
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pybit
 python-dotenv
+pytest

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -1,0 +1,64 @@
+import sys
+from pathlib import Path
+import pytest
+from unittest.mock import MagicMock
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from bot import BybitTradingBot
+
+
+@pytest.fixture
+def session():
+    return MagicMock()
+
+
+def test_place_order_calls_api(session):
+    bot = BybitTradingBot(session)
+    bot.place_order("BTCUSDT", "Buy", 100, 10)
+    session.set_leverage.assert_called_once_with(
+        category="linear",
+        symbol="BTCUSDT",
+        buyLeverage="10",
+        sellLeverage="10",
+    )
+    session.place_order.assert_called_once_with(
+        category="linear",
+        symbol="BTCUSDT",
+        side="Buy",
+        orderType="Market",
+        qty="1000",
+        timeInForce="ImmediateOrCancel",
+    )
+
+
+def test_close_position_calls_api(session):
+    bot = BybitTradingBot(session)
+    bot.close_position("BTCUSDT", "Buy", 100, 10)
+    session.place_order.assert_called_once_with(
+        category="linear",
+        symbol="BTCUSDT",
+        side="Sell",
+        orderType="Market",
+        qty="1000",
+        timeInForce="ImmediateOrCancel",
+        reduceOnly=True,
+    )
+
+
+def test_invalid_amount(session):
+    bot = BybitTradingBot(session)
+    with pytest.raises(ValueError):
+        bot.place_order("BTCUSDT", "Buy", 70, 10)
+
+
+def test_invalid_leverage(session):
+    bot = BybitTradingBot(session)
+    with pytest.raises(ValueError):
+        bot.place_order("BTCUSDT", "Buy", 100, 5)
+
+
+def test_invalid_symbol(session):
+    bot = BybitTradingBot(session)
+    with pytest.raises(ValueError):
+        bot.place_order("ADAUSDT", "Buy", 100, 10)


### PR DESCRIPTION
## Summary
- add `BybitTradingBot` class to open and close USDT orders
- document order capabilities and how to run tests
- add pytest dependencies and unit tests

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892f6864e788320ba477a860605458f