### PR TITLE
Add moving average crossover trading strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,39 @@
 # o3cripto
 
-Simple Bybit futures trading bot example.
+Простой пример торгового бота для фьючерсов Bybit.
 
-## Setup
+## Установка
 
-1. Create a `.env` file based on `.env.example` and fill in your Bybit API credentials.
-2. Install dependencies:
+1. Создайте файл `.env` на основе `.env.example` и заполните его своими API‑ключами Bybit.
+2. Установите зависимости:
    ```bash
    pip install -r requirements.txt
    ```
-3. Run the bot:
+3. Запустите бота:
    ```bash
    python bot.py
    ```
 
-This example fetches and prints account balance using Bybit's demo environment.
-It also provides helpers for placing and closing leveraged market orders on
-`BTCUSDT`, `ETHUSDT`, `SOLUSDT`, `XRPUSDT`, `DOGEUSDT` and `BNBUSDT`.
+Пример получает и выводит баланс счёта в тестовой среде Bybit.
+Также он содержит вспомогательные функции для открытия и закрытия рыночных ордеров с плечом на парах
+`BTCUSDT`, `ETHUSDT`, `SOLUSDT`, `XRPUSDT`, `DOGEUSDT` и `BNBUSDT`.
 
-## Testing
+## Торговые стратегии
 
-Run unit tests with:
+В бота встроен пример стратегии пересечения скользящих средних через функцию
+`trade_with_ma`, которая торгует, когда 5‑периодная SMA пересекает 20‑периодную SMA.
+Для автономной работы в 2025 году можно расширить бота следующими методами:
 
+- **Прогнозирование с подкреплением**, обученное на данных ордербука.
+- **Статистический арбитраж** на коррелированных парах для поиска неправильного ценообразования.
+- **Системы пробоя волатильности** с динамическим управлением рисками.
+- **Анализ настроений** из новостей и социальных сетей для фильтрации сделок.
 
+## Тестирование
+
+Запустить модульные тесты:
+
+```bash
 python -m unittest tests.test_bot
+```
 

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -75,6 +75,19 @@ class TestBybitTradingBot(unittest.TestCase):
         )
         self.assertIn("BTCUSDT: actively sold, price decreases", cm.output[0])
 
+    def test_ma_crossover_signal_buy(self):
+        candles = [[0, 0, 0, 0, "110", 0]] * 5 + [[0, 0, 0, 0, "100", 0]] * 45
+        self.session.get_kline.return_value = {"result": {"list": candles}}
+        signal = self.bot.ma_crossover_signal("BTCUSDT")
+        self.assertEqual(signal, "Buy")
+
+    def test_trade_with_ma_calls_place_order(self):
+        candles = [[0, 0, 0, 0, "110", 0]] * 5 + [[0, 0, 0, 0, "100", 0]] * 45
+        self.session.get_kline.return_value = {"result": {"list": candles}}
+        self.bot.place_order = MagicMock()
+        self.bot.trade_with_ma("BTCUSDT", 100, 10)
+        self.bot.place_order.assert_called_once_with("BTCUSDT", "Buy", 100, 10)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- implement SMA crossover signal and trading helper
- document strategy options for autonomous trading in 2025
- test moving-average based trade path
- translate README to Russian and auto-execute moving average trades for all pairs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689303809f7883209ef2470213557b23