### PR TITLE
handle leverage already set

### DIFF
--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -88,6 +88,13 @@ class TestBybitTradingBot(unittest.TestCase):
         self.bot.trade_with_ma("BTCUSDT", 100, 10)
         self.bot.place_order.assert_called_once_with("BTCUSDT", "Buy", 100, 10)
 
+    def test_place_order_ignores_leverage_error(self):
+        self.session.set_leverage.side_effect = Exception(
+            "leverage not modified (ErrCode: 110043)"
+        )
+        self.bot.place_order("BTCUSDT", "Buy", 100, 10)
+        self.session.place_order.assert_called_once()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- ignore Bybit 110043 errors by wrapping set_leverage in _set_leverage
- test that place_order still proceeds when leverage is already set

## Testing
- `pytest -q`
- `python bot.py`


------
https://chatgpt.com/codex/tasks/task_e_689307842e5083208ceaff662cf4971e